### PR TITLE
Fix beacons sql example parameter count

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ideas and concept by: Kas C, [Pieter1024](https://github.com/pieter1024) and Chr
   * `INSERT INTO teams VALUES(lower(hex(randomblob(16))), 'Team Unicorn');`
   * Field 1, the id, must be a 32 characters hex string
 * Insert the beacons using `sqlite3 data/zwerfdata.db`:
-  * `INSERT INTO beacons VALUES(lower(hex(randomblob(16))), 'First', 1, 1);`
+  * `INSERT INTO beacons VALUES(lower(hex(randomblob(16))), 'First', 1);`
   * Field 1, the id, must be a 32 characters hex string
   * Field 2, the name, a unique name for the beacon. Will be visible to the teams (website, QR-label)
   * Field 3, the score, the score for this beacon


### PR DESCRIPTION
The example within the README.md file had an incorrect argument count for the beacons INSERT example.